### PR TITLE
allow "panic button" apps to lock Twik

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -87,6 +87,10 @@
             </intent-filter>
         </activity>
         <activity
+            android:name=".ExitActivity"
+            android:theme="@android:style/Theme.NoDisplay" />
+
+        <activity
             android:name=".tutorial.TutorialActivity"
             android:noHistory="true"
             android:screenOrientation="portrait"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -77,6 +77,16 @@
         <receiver android:name=".util.MasterKeyAlarmManager" />
 
         <activity
+            android:name=".PanicResponderActivity"
+            android:launchMode="singleInstance"
+            android:noHistory="true"
+            android:theme="@android:style/Theme.NoDisplay">
+            <intent-filter>
+                <action android:name="info.guardianproject.panic.action.TRIGGER" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+        <activity
             android:name=".tutorial.TutorialActivity"
             android:noHistory="true"
             android:screenOrientation="portrait"

--- a/app/src/main/java/com/reddyetwo/hashmypass/app/ExitActivity.java
+++ b/app/src/main/java/com/reddyetwo/hashmypass/app/ExitActivity.java
@@ -1,0 +1,36 @@
+
+package com.reddyetwo.hashmypass.app;
+
+import android.annotation.SuppressLint;
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Build;
+import android.os.Bundle;
+
+public class ExitActivity extends Activity {
+
+    @SuppressLint("NewApi")
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        if (Build.VERSION.SDK_INT >= 21) {
+            finishAndRemoveTask();
+        } else {
+            finish();
+        }
+
+        System.exit(0);
+    }
+
+    public static void exitAndRemoveFromRecentApps(Activity activity) {
+        Intent intent = new Intent(activity, ExitActivity.class);
+
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK
+                | Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS
+                | Intent.FLAG_ACTIVITY_CLEAR_TASK
+                | Intent.FLAG_ACTIVITY_NO_ANIMATION);
+
+        activity.startActivity(intent);
+    }
+}

--- a/app/src/main/java/com/reddyetwo/hashmypass/app/PanicResponderActivity.java
+++ b/app/src/main/java/com/reddyetwo/hashmypass/app/PanicResponderActivity.java
@@ -19,6 +19,7 @@ public class PanicResponderActivity extends Activity {
         Intent intent = getIntent();
         if (intent != null && PANIC_TRIGGER_ACTION.equals(intent.getAction())) {
             TwikApplication.getInstance().wipeCachedMasterKey();
+            ExitActivity.exitAndRemoveFromRecentApps(this);
         }
 
         if (Build.VERSION.SDK_INT >= 21) {

--- a/app/src/main/java/com/reddyetwo/hashmypass/app/PanicResponderActivity.java
+++ b/app/src/main/java/com/reddyetwo/hashmypass/app/PanicResponderActivity.java
@@ -1,0 +1,30 @@
+
+package com.reddyetwo.hashmypass.app;
+
+import android.annotation.SuppressLint;
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Build;
+import android.os.Bundle;
+
+public class PanicResponderActivity extends Activity {
+
+    public static final String PANIC_TRIGGER_ACTION = "info.guardianproject.panic.action.TRIGGER";
+
+    @SuppressLint("NewApi")
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        Intent intent = getIntent();
+        if (intent != null && PANIC_TRIGGER_ACTION.equals(intent.getAction())) {
+            TwikApplication.getInstance().wipeCachedMasterKey();
+        }
+
+        if (Build.VERSION.SDK_INT >= 21) {
+            finishAndRemoveTask();
+        } else {
+            finish();
+        }
+    }
+}


### PR DESCRIPTION
We've been developing "panic button" features in our apps for years, and now we are working to make a more flexible and open ecosystem of apps that can both trigger other apps, or respond to triggers. Since Twik already includes a "lock" feature, it is a natural panic responder app. This setup allows for easy configuration of a single trigger action which can then trigger multiple apps.

The first commit adds support for receiving the panic trigger. The second commit wipes Twik from the Recent Apps when it is responding to a panic trigger.

The first panic button app that sends this kind of trigger is called Ripple, and it is available here:
https://github.com/guardianproject/ripple
https://play.google.com/store/apps/details?id=info.guardianproject.ripple

I'm adding support to this app right now:
https://panicbutton.io/
https://play.google.com/store/apps/details?id=org.iilab.pb

This is all code that I wrote, and you can have it under any license you want, including public domain. I waive all my copyright claims to it.

You can see an example of this user experience in this video:
https://www.youtube.com/watch?v=mS1gstS6YS8

More info on the panic kit work here:
https://dev.guardianproject.info/projects/panic/wiki
