### PR TITLE
Fix link to extension in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ Keeping up with todays password requirements isn’t easy. On the one hand, you 
 
 Twik works in a different way. You have to provide a private key that will be stored in the device, and think of a strong master key that will not be stored anywhere. Any time you need to generate a password for a website, you must type your master key. The combination of the master key, the private key, and the website will be used to generate a unique, strong password. Since passwords are generated each time, even if one of them is compromised the rest would be safe. Twik also integrates with any web browser, so that you can generate a password quickly by sharing a website with Twik from the browser.
 
-Twik is also available as a [Chrome Extension](https://chrome.google
-.com/webstore/detail/twik-password-generator/aabbbcmaljeehpfjoepomhbocldfkinc) in the Chrome Web Store.
+Twik is also available as a [Chrome Extension](https://chrome.google.com/webstore/detail/twik-password-generator/aabbbcmaljeehpfjoepomhbocldfkinc) in the Chrome Web Store.
 
 Twik features include:
 - Several profiles, each with its own private key


### PR DESCRIPTION
The link to the Chrome extension was broken due to a line break in the middle of the URL.